### PR TITLE
Improve Bluetooth provisioning workflow

### DIFF
--- a/app/src/main/java/com/robofer/app/bt/BtClient.java
+++ b/app/src/main/java/com/robofer/app/bt/BtClient.java
@@ -59,8 +59,14 @@ public class BtClient {
     public void connect() throws Exception {
         if (device == null) throw new IllegalStateException("No device selected");
         adapter.cancelDiscovery();
-        socket = device.createRfcommSocketToServiceRecord(UUID_SPP);
-        socket.connect();
+        try {
+            socket = device.createRfcommSocketToServiceRecord(UUID_SPP);
+            socket.connect();
+        } catch (SecurityException e) {
+            // Fall back to an insecure socket to rule out pairing issues.
+            socket = device.createInsecureRfcommSocketToServiceRecord(UUID_SPP);
+            socket.connect();
+        }
         in = socket.getInputStream();
         out = socket.getOutputStream();
     }


### PR DESCRIPTION
## Summary
- allow selecting already paired devices and offer scan fallback
- try insecure RFCOMM socket when secure connect throws SecurityException

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c29177948321b2888999726a27d8